### PR TITLE
Lv 4. API 로깅 - AOP 기반 로깅 구현

### DIFF
--- a/src/main/java/org/example/expert/common/annotation/AdminLog.java
+++ b/src/main/java/org/example/expert/common/annotation/AdminLog.java
@@ -1,0 +1,11 @@
+package org.example.expert.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdminLog {
+}

--- a/src/main/java/org/example/expert/common/aop/AdminApiLoggingAspect.java
+++ b/src/main/java/org/example/expert/common/aop/AdminApiLoggingAspect.java
@@ -1,0 +1,69 @@
+package org.example.expert.common.aop;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.lang.annotation.Annotation;
+import java.time.LocalDateTime;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AdminApiLoggingAspect {
+
+    private final HttpServletRequest httpServletRequest;
+    private final ObjectMapper objectMapper;
+
+    @Around("@annotation(org.example.expert.common.annotation.AdminLog)")
+    public Object logAdminApi(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        // 요청 시각
+        long startTime = System.currentTimeMillis();
+
+        // 사용자 ID 추출
+        Long userId = (Long) httpServletRequest.getAttribute("userId");
+
+        // 요청 URL
+        String requestUrl = httpServletRequest.getRequestURI();
+
+        // 요청 본문
+        Annotation[][] parameterAnnotations = ((MethodSignature) joinPoint.getSignature()).getMethod().getParameterAnnotations();
+        Object[] args = joinPoint.getArgs();
+        Object requestBody = null;
+        for (int i = 0; i < parameterAnnotations.length; i++) {
+            for (Annotation annotation : parameterAnnotations[i]) {
+                if (annotation.annotationType().equals(RequestBody.class)) {
+                    requestBody = args[i];
+                    break;
+                }
+            }
+            if (requestBody != null) break;
+        }
+
+        log.info(
+            "[ADMIN API REQUEST] userId={}, url={}, time={}, requestBody={}",
+            userId, requestUrl, LocalDateTime.now(), objectMapper.writeValueAsString(requestBody)
+        );
+
+        // 메서드 실행
+        Object response = joinPoint.proceed();
+
+        long duration = System.currentTimeMillis() - startTime;
+
+        log.info(
+            "[ADMIN API RESPONSE] userId={}, url={}, duration={}ms, responseBody={}",
+            userId, requestUrl, duration, objectMapper.writeValueAsString(response)
+        );
+
+        return response;
+    }
+}

--- a/src/main/java/org/example/expert/domain/comment/controller/CommentAdminController.java
+++ b/src/main/java/org/example/expert/domain/comment/controller/CommentAdminController.java
@@ -1,6 +1,7 @@
 package org.example.expert.domain.comment.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.expert.common.annotation.AdminLog;
 import org.example.expert.domain.comment.service.CommentAdminService;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,6 +13,7 @@ public class CommentAdminController {
 
     private final CommentAdminService commentAdminService;
 
+    @AdminLog
     @DeleteMapping("/admin/comments/{commentId}")
     public void deleteComment(@PathVariable long commentId) {
         commentAdminService.deleteComment(commentId);

--- a/src/main/java/org/example/expert/domain/user/controller/UserAdminController.java
+++ b/src/main/java/org/example/expert/domain/user/controller/UserAdminController.java
@@ -1,6 +1,7 @@
 package org.example.expert.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.expert.common.annotation.AdminLog;
 import org.example.expert.domain.user.dto.request.UserRoleChangeRequest;
 import org.example.expert.domain.user.service.UserAdminService;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -14,6 +15,7 @@ public class UserAdminController {
 
     private final UserAdminService userAdminService;
 
+    @AdminLog
     @PatchMapping("/admin/users/{userId}")
     public void changeUserRole(@PathVariable long userId, @RequestBody UserRoleChangeRequest userRoleChangeRequest) {
         userAdminService.changeUserRole(userId, userRoleChangeRequest);

--- a/src/test/java/org/example/expert/integration/AdminApiLoggingTest.java
+++ b/src/test/java/org/example/expert/integration/AdminApiLoggingTest.java
@@ -1,0 +1,83 @@
+package org.example.expert.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.expert.config.JwtUtil;
+import org.example.expert.domain.user.dto.request.UserRoleChangeRequest;
+import org.example.expert.domain.user.enums.UserRole;
+import org.example.expert.domain.user.service.UserAdminService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(OutputCaptureExtension.class)
+public class AdminApiLoggingTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserAdminService userAdminService;
+
+    @Test
+    public void 어드민_댓글_삭제_로깅_통합_테스트(CapturedOutput output) throws Exception {
+        //given
+        String token = jwtUtil.createToken(123L, "test@example.com", UserRole.ADMIN);
+
+        //when
+        mockMvc.perform(
+                delete("/admin/comments/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", token)
+        ).andExpect(status().isOk());
+
+        // then
+        assertThat(output)
+                .contains("[ADMIN API REQUEST] userId=123, url=/admin/comments/1")
+                .contains("[ADMIN API RESPONSE] userId=123, url=/admin/comments/1");
+    }
+
+    @Test
+    public void 어드민_UserRole_변경_로깅_통합_테스트(CapturedOutput output) throws Exception {
+        //given
+        String token = jwtUtil.createToken(123L, "test@example.com", UserRole.ADMIN);
+        UserRoleChangeRequest userRoleChangeRequest = new UserRoleChangeRequest("ADMIN");
+
+        doNothing().when(userAdminService).changeUserRole(eq(123L), any(UserRoleChangeRequest.class));
+
+        //when
+        mockMvc.perform(
+                patch("/admin/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", token)
+                        .content(objectMapper.writeValueAsString(userRoleChangeRequest))
+        ).andExpect(status().isOk());
+
+        // then
+        assertThat(output)
+                .contains("[ADMIN API REQUEST] userId=123, url=/admin/users/1")
+                .contains("[ADMIN API RESPONSE] userId=123, url=/admin/users/1");
+    }
+}


### PR DESCRIPTION
- @AdminLog 선언
- AOP 적용
  - 어드민 API 메서드 실행 전후에 요청/응답 데이터 로깅 (Around)
  - 로깅 내용: 요청한 사용자의 ID, API 요청 시각, API 요청 URL, 요청 본문(RequestBody), 응답 본문(ResponseBody)
- 테스트 코드 작성하여 로깅 기능 검증